### PR TITLE
Add Eve App History Support for VOC

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "homebridge-iam-voc",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "description": "A HomeBridge plugin for Applied Sensors iAM USB indoor air quality moitor.",
     "main": "main.js",
     "scripts": {
@@ -34,6 +34,7 @@
     },
     "homepage": "https://github.com/toto/homebridge-iam-voc",
     "dependencies": {
-        "iam-voc-monitor": "^1.0.0"
+        "iam-voc-monitor": "^1.0.0",
+        "fakegato-history": "^0.5.3"
     }
 }


### PR DESCRIPTION
Add the custom Eve Room Characteristic that helps us
expose PPM values over time to the graphing utility.
This is achieved by using Fakegato-History and introducing
it as a dependency to this NPM.

![IMG_4217](https://user-images.githubusercontent.com/5174440/54773765-866a2d00-4c0a-11e9-9a1c-026d2b63d858.PNG)
![IMG_7E7C25CE9760-1](https://user-images.githubusercontent.com/5174440/54773766-8702c380-4c0a-11e9-8353-16b8bd512710.jpeg)
